### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/qavajs/memory/security/code-scanning/1](https://github.com/qavajs/memory/security/code-scanning/1)

To fix this issue, the workflow should include a `permissions` block explicitly granting only the minimum permissions necessary. In this context, the steps only involve reading repository contents (for checking out code and installing dependencies), so the only required permission is `contents: read`. The `permissions` block can be placed at the workflow root, which applies it to all jobs, or inside the job definition. For clarity and maintainability, add it directly below the workflow name definition, making it universal for all jobs in this workflow. No additional imports, methods, or definitions are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
